### PR TITLE
update to build-number 6

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,7 @@ cd build
 
 cmake -G "NMake Makefiles" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D CMAKE_BUILD_TYPE=Release ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,11 +65,14 @@ about:
   home: https://github.com/libkml/libkml
   license: BSD 3-Clause
   license_file: LICENSE
+  license_family: BSD
   summary: 'Reference implementation of OGC KML 2.2'
   description: |
     This is Google's reference implementation of OGC KML 2.2.
     It also includes implementations of Google's gx: extensions used by Google Earth,
     as well as several utility libraries for working with other formats.
+  doc_url: https://github.com/libkml/libkml
+  dev_url: https://github.com/libkml/libkml
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,7 @@ test:
 
 about:
   home: https://github.com/libkml/libkml
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
   summary: 'Reference implementation of OGC KML 2.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - {{ compiler('cxx') }}
     - make      # [unix]
     - m2-patch  # [win]
+    - curl
   host:
     - expat
     - libiconv  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - empty_char.patch  # [win and py>35]
 
 build:
-  number: 5
+  number: 6
   run_exports:
     # no ABI lab result.  Pinning to major-minor as conda-forge has.
     - {{ pin_subpackage('libkml', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,8 @@ requirements:
     - libboost
 
 test:
+  requires:
+    - conda-build  # [not win]
   commands:
     - test -f $PREFIX/lib/libkmlbase.so.1  # [linux]
     - test -f $PREFIX/lib/libkmlbase.dylib  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     # Patches for vc14. If this works we should wrapit in a ifdef and send the patch upstream.
     - empty_char.patch  # [win and py>35]
+    - uriparse.patch
 
 build:
   number: 6
@@ -27,6 +28,7 @@ requirements:
     - {{ compiler('cxx') }}
     - make      # [unix]
     - m2-patch  # [win]
+    - patch     # [not win]
     - curl
   host:
     - expat

--- a/recipe/uriparse.patch
+++ b/recipe/uriparse.patch
@@ -1,0 +1,12 @@
+Index: libkml-1.3.0/cmake/External_uriparser.cmake
+===================================================================
+--- libkml-1.3.0.orig/cmake/External_uriparser.cmake
++++ libkml-1.3.0/cmake/External_uriparser.cmake
+@@ -1,6 +1,6 @@
+ ExternalProject_Add(URIPARSER
+   PREFIX URIPARSER
+-  URL "http://sourceforge.net/projects/uriparser/files/Sources/0.7.5/uriparser-0.7.5.tar.bz2/download"
++  URL "http://sourceforge.net/projects/uriparser/files/Sources/0.7.5/uriparser-0.7.5.tar.gz/download"
+   URL_MD5 4f4349085fe5de33bcae8d0f26649593
+   BINARY_DIR ${CMAKE_BINARY_DIR}/URIPARSER/build
+   DOWNLOAD_DIR ${DOWNLOAD_LOCATION}

--- a/recipe/uriparse.patch
+++ b/recipe/uriparse.patch
@@ -2,11 +2,13 @@ Index: libkml-1.3.0/cmake/External_uriparser.cmake
 ===================================================================
 --- libkml-1.3.0.orig/cmake/External_uriparser.cmake
 +++ libkml-1.3.0/cmake/External_uriparser.cmake
-@@ -1,6 +1,6 @@
+@@ -1,7 +1,7 @@
  ExternalProject_Add(URIPARSER
    PREFIX URIPARSER
 -  URL "http://sourceforge.net/projects/uriparser/files/Sources/0.7.5/uriparser-0.7.5.tar.bz2/download"
+-  URL_MD5 4f4349085fe5de33bcae8d0f26649593
 +  URL "http://sourceforge.net/projects/uriparser/files/Sources/0.7.5/uriparser-0.7.5.tar.gz/download"
-   URL_MD5 4f4349085fe5de33bcae8d0f26649593
++  URL_MD5 459c2786758929b92bfbd0cee25b5aa0
    BINARY_DIR ${CMAKE_BINARY_DIR}/URIPARSER/build
    DOWNLOAD_DIR ${DOWNLOAD_LOCATION}
+   PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/cmake/UriParser_cmake_lists_txt ${CMAKE_BINARY_DIR}/URIPARSER/src/URIPARSER/CMakeLists.txt


### PR DESCRIPTION
Do a rebuild for Windows architecture to make sure we don't provide library files using debug-crt ...

* adjusted invokation of cmake to explicit use release-build variant
* adjust url for uriparser as on sourceforge there is no .bz2 variant for that version anymore, just a .gz one.
* raised build-number to 6
